### PR TITLE
improve readme for people who are just getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ Note: v2 boards allow configuring both the layout and the enabled/disabled shows
 
 ---
 
+## Building/Development
+
+### Setup
+- `git submodule init`
+- `git submodule update`
+
+### Build
+
+- `./build.sh new`
+
 ## Libraries used
 
-BMX280 library from <https://github.com/Erriez/ErriezBMX280> (v1.0.1)  
-FastLED library from <https://github.com/FastLED/FastLED> (v3.6.0)  
+- BMX280 library from <https://github.com/Erriez/ErriezBMX280> (v1.0.1)
+- FastLED library from <https://github.com/FastLED/FastLED> (v3.6.0)

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-BUILD_DIR=/tmp/build
+set -euo pipefail
+
+BUILD_DIR=$(mktemp -d)
 mkdir -p ${BUILD_DIR}
 mkdir -p ./build
 


### PR DESCRIPTION
I put some stuff in the README, but also made the build work on Mac by creating a temp directory from scratch rather than using a hardcoded one that only would work on Linux.

I didn't put a ton of thought into where this stuff should go in the README. I'm also not sure if the Arduino software is even required at this point - maybe we should note that it isn't if it's not?